### PR TITLE
check for arrow==undefined must hapen before check for arrow.length==0

### DIFF
--- a/msdropdown/js/uncompressed.jquery.dd.js
+++ b/msdropdown/js/uncompressed.jquery.dd.js
@@ -178,7 +178,7 @@
 			sText = $("#"+elementid+" option:selected").text();
 			arrow = $("#"+elementid+" option:selected").prop("title");
 		};
-		arrow = (arrow.length==0 || arrow==undefined || options.showIcon==false || options.useSprite!=false) ? "" : '<img src="'+arrow+'" align="absmiddle" /> ';		
+		arrow = (arrow==undefined || arrow.length==0 || options.showIcon==false || options.useSprite!=false) ? "" : '<img src="'+arrow+'" align="absmiddle" /> ';		
 		var sDiv = '<div id="'+titleid+'" class="'+styles.ddTitle+'"';
 		sDiv += '>';
 		sDiv += '<span id="'+arrowid+'" class="'+styles.arrow+'"></span><span class="'+styles.ddTitleText+'" id="'+titletextid+'">'+arrow + '<span class="'+styles.ddTitleText+'">'+sText+'</span></span></div>';


### PR DESCRIPTION
Thanks for this awesome plugin.  When title is not present, the current code dies because the check to see if it's empty happens after the check to see what its value is.  Simple cut-and-paste has solved this problem for me.  Thought I'd share it back.
