### PR TITLE
Fix the Webpack5 deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "style-loader": "^3.2.1",
     "webpack": "^5.52.0",
     "webpack-cli": "^4.7.2",
-    "webpack-fix-style-only-entries": "^0.6.1"
+    "webpack-remove-empty-scripts": "^1.0.4"
   },
   "directories": {
     "doc": "docs"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ const fs = require('fs');
 
 const version = "4.0.2";
 
-const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
+const RemoveEmptyScripts = require("webpack-remove-empty-scripts");
 
 
 let entries = {
@@ -62,7 +62,7 @@ module.exports = {
     },
     plugins: [
         new CleanWebpackPlugin(),
-        new FixStyleOnlyEntriesPlugin(),
+        new RemoveEmptyScripts(),
 
         new CopyPlugin({
             patterns: copyFolders,


### PR DESCRIPTION
Hello,

this project uses the outdated [webpack-fix-style-only-entries](https://www.npmjs.com/package/webpack-fix-style-only-entries) plugin that is incompatible with `Webpack 5`.

Using `npm run prod` appear the deprecation warnings:
```
webpack-fix-style-only-entries:
(node:18462) [DEP_WEBPACK_CHUNK_ENTRY_MODULE] DeprecationWarning: Chunk.entryModule: Use new ChunkGraph API
(node:18462) [DEP_WEBPACK_MODULE_INDEX] DeprecationWarning: Module.index: Use new ModuleGraph API
(node:18462) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: chunk.files was changed from Array to Set (using Array method 'filter' is deprecated)
```

The author of the [webpack-fix-style-only-entries](https://www.npmjs.com/package/webpack-fix-style-only-entries) plugin recommends using the [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts) plugin for Webpack 5.

This PR just replaces the outdated plugin with the actual version.